### PR TITLE
Respect client Accept-Encoding quality values

### DIFF
--- a/fileserver.go
+++ b/fileserver.go
@@ -5,18 +5,51 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"sort"
 	"strings"
 
 	"github.com/golang/gddo/httputil/header"
 )
 
-const (
-	gzipEncoding  = "gzip"
-	gzipExtension = ".gz"
+// Encoding represents an Accept-Encoding. All of these fields are pre-populated
+// in the supportedEncodings variable, except the clientPreference which is updated
+// (by copying a value from supportedEncodings) when examining client headers.
+type encoding struct {
+	name             string  // the encoding name
+	extension        string  // the file extension (including a leading dot)
+	clientPreference float64 // the client's preference
+	serverPreference int     // the server's preference
+}
 
-	brotliEncoding  = "br"
-	brotliExtension = ".br"
-)
+// Helper type to sort encodings, using clientPreference first, and then
+// serverPreference as a tie breaker. This sorts in *DESCENDING* order, rather
+// than the usual ascending order.
+type encodingByPreference []encoding
+
+// Implement the sort.Interface interface
+func (e encodingByPreference) Len() int { return len(e) }
+func (e encodingByPreference) Less(i, j int) bool {
+	if e[i].clientPreference == e[j].clientPreference {
+		return e[i].serverPreference > e[j].serverPreference
+	}
+	return e[i].clientPreference > e[j].clientPreference
+}
+func (e encodingByPreference) Swap(i, j int) { e[i], e[j] = e[j], e[i] }
+
+// Supported encodings. Higher server preference means the encoding will be when
+// the client doesn't have an explicit preference.
+var supportedEncodings = [...]encoding{
+	{
+		name:             "gzip",
+		extension:        ".gz",
+		serverPreference: 1,
+	},
+	{
+		name:             "br",
+		extension:        ".br",
+		serverPreference: 2,
+	},
+}
 
 type fileHandler struct {
 	root http.FileSystem
@@ -42,18 +75,6 @@ func FileServer(root http.FileSystem) http.Handler {
 	return &fileHandler{root}
 }
 
-func acceptable(r *http.Request, encoding string) bool {
-	for _, aspec := range header.ParseAccept(r.Header, "Accept-Encoding") {
-		if aspec.Value == encoding && aspec.Q == 0.0 {
-			return false
-		}
-		if (aspec.Value == encoding || aspec.Value == "*") && aspec.Q > 0.0 {
-			return true
-		}
-	}
-	return false
-}
-
 func (f *fileHandler) openAndStat(path string) (http.File, os.FileInfo, error) {
 	file, err := f.root.Open(path)
 	var info os.FileInfo
@@ -72,6 +93,72 @@ func (f *fileHandler) openAndStat(path string) (http.File, os.FileInfo, error) {
 	return file, info, nil
 }
 
+// Build a []encoding based on the Accept-Encoding header supplied by the
+// client. The returned list will be sorted from most-preferred to
+// least-preferred.
+func acceptable(r *http.Request) []encoding {
+	// list of acceptable encodings, as provided by the client
+	acceptEncodings := make([]encoding, 0, len(supportedEncodings))
+
+	// the quality of the * encoding; this will be -1 if not sent by client
+	starQuality := -1.
+
+	// encodings we've already seen (used to handle duplicates and *)
+	seenEncodings := make(map[string]interface{})
+
+	// match the client accept encodings against the ones we support
+	for _, aspec := range header.ParseAccept(r.Header, "Accept-Encoding") {
+		if _, alreadySeen := seenEncodings[aspec.Value]; alreadySeen {
+			continue
+		}
+		seenEncodings[aspec.Value] = nil
+		if aspec.Value == "*" {
+			starQuality = aspec.Q
+			continue
+		}
+		for _, known := range supportedEncodings {
+			if aspec.Value == known.name && aspec.Q != 0 {
+				enc := known
+				enc.clientPreference = aspec.Q
+				acceptEncodings = append(acceptEncodings, enc)
+				break
+			}
+		}
+	}
+
+	// If the client sent Accept: *, add all our extra known encodings. Use
+	// the quality of * as the client quality for the encoding.
+	if starQuality != -1. {
+		for _, known := range supportedEncodings {
+			if _, seen := seenEncodings[known.name]; !seen {
+				enc := known
+				enc.clientPreference = starQuality
+				acceptEncodings = append(acceptEncodings, enc)
+			}
+		}
+	}
+
+	// sort the encoding based on client/server preference
+	sort.Sort(encodingByPreference(acceptEncodings))
+	return acceptEncodings
+}
+
+// Find the best file to serve based on the client's Accept-Encoding, and which
+// files actually exist on the filesystem. If no file was found that can satisfy
+// the request, the error field will be non-nil.
+func (f *fileHandler) findBestFile(w http.ResponseWriter, r *http.Request, fpath string) (http.File, os.FileInfo, error) {
+	// find the best matching file
+	for _, enc := range acceptable(r) {
+		if file, info, err := f.openAndStat(fpath + enc.extension); err == nil {
+			w.Header().Set("Content-Encoding", enc.name)
+			return file, info, nil
+		}
+	}
+
+	// if nothing found, try the base file with no content-encoding
+	return f.openAndStat(fpath)
+}
+
 func (f *fileHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	upath := r.URL.Path
 	if !strings.HasPrefix(upath, "/") {
@@ -85,38 +172,14 @@ func (f *fileHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	// Try for a compressed version if appropriate
-	var file http.File
-	var err error
-	var info os.FileInfo
 
-	foundAcceptable := false
-
-	if acceptable(r, brotliEncoding) {
-		file, info, err = f.openAndStat(fpath + brotliExtension)
-		if err == nil {
-			foundAcceptable = true
-			w.Header().Set("Content-Encoding", brotliEncoding)
-		}
-
-	}
-
-	if !foundAcceptable && acceptable(r, gzipEncoding) {
-		file, info, err = f.openAndStat(fpath + gzipExtension)
-		if err == nil {
-			foundAcceptable = true
-			w.Header().Set("Content-Encoding", gzipEncoding)
-		}
-	}
-	// If we didn't manage to open a compressed version, try for uncompressed
-	if !foundAcceptable {
-		file, info, err = f.openAndStat(fpath)
-	}
-	if err != nil {
-		// Doesn't exist compressed or uncompressed
-		http.NotFound(w, r)
+	// Find the best acceptable file, including trying uncompressed
+	if file, info, err := f.findBestFile(w, r, fpath); err == nil {
+		http.ServeContent(w, r, fpath, info.ModTime(), file)
+		file.Close()
 		return
 	}
-	defer file.Close()
-	http.ServeContent(w, r, fpath, info.ModTime(), file)
+
+	// Doesn't exist, compressed or uncompressed
+	http.NotFound(w, r)
 }

--- a/fileserver_test.go
+++ b/fileserver_test.go
@@ -10,32 +10,61 @@ import (
 	"testing"
 )
 
-var trueHeaders = [...]string{
-	"gzip",
-	"*",
-	"compress,gzip;q=0.1",
-	"compress, * ;q=1",
-	"deflate ;q=0.3, gzip ;q=0.7, x-foo",
-}
-
-var falseHeaders = [...]string{
-	"gzip;q=0,*",
-	"deflate; gzip ;q=0 , x-foo,*",
-}
-
-func TestGzipAcceptable(t *testing.T) {
-	var req http.Request
-	req.Header = make(http.Header)
-	for _, ac := range trueHeaders {
-		req.Header.Set("Accept-Encoding", ac)
-		if !acceptable(&req, gzipEncoding) {
-			t.Errorf("acceptable(%s, gzip) false, want true", ac)
+// foundEncoding checks if a given encoding was seen in the acceptEncodings list
+func foundEncoding(acceptEncodings []encoding, target string) bool {
+	for _, seen := range acceptEncodings {
+		if seen.name == target {
+			return true
 		}
 	}
-	for _, ac := range falseHeaders {
-		req.Header.Set("Accept-Encoding", ac)
-		if acceptable(&req, gzipEncoding) {
-			t.Errorf("acceptable(%s, gzip) true, want false", ac)
+	return false
+}
+
+// Test various cases where gzip is or is not acceptable
+func TestGzipAcceptable(t *testing.T) {
+	req := http.Request{Header: http.Header{}}
+	for _, info := range []struct {
+		hdr    string // the Accept-Encoding header
+		expect bool   // whether we expect gzip to be acceptable
+	}{
+		{"gzip", true},
+		{"*", true},
+		{"compress,gzip;q=0.1", true},
+		{"compress, * ;q=1", true},
+		{"deflate ;q=0.3, gzip ;q=0.7, x-foo", true},
+		{"gzip;q=0,*", false},
+		{"deflate; gzip ;q=0 , x-foo,*", false},
+	} {
+		req.Header.Set("Accept-Encoding", info.hdr)
+		accepted := foundEncoding(acceptable(&req), "gzip")
+		if accepted != info.expect {
+			t.Errorf("expected gzip accept to be %t, instead got %t, for header %s", info.expect, accepted, info.hdr)
+		}
+	}
+}
+
+// Test that the server respects client preferences
+func TestPreference(t *testing.T) {
+	req := http.Request{Header: http.Header{}}
+
+	// the client doesn't set any preferences, so we should pick br
+	for _, info := range []struct {
+		hdr    string // the Accept-Encoding string
+		expect string // the expected encoding chosen by the server
+	}{
+		{"*", "br"},
+		{"gzip, deflate, br", "br"},
+		{"gzip, deflate, br;q=0.5", "gzip"},
+	} {
+		req.Header.Set("Accept-Encoding", info.hdr)
+		acceptEncodings := acceptable(&req)
+		if len(acceptEncodings) == 0 {
+			t.Errorf("server failed to find an accept encoding")
+			continue
+		}
+		best := acceptEncodings[0].name
+		if best != info.expect {
+			t.Errorf("server chose %s but we expected %s for header %s", best, info.expect, info.hdr)
 		}
 	}
 }


### PR DESCRIPTION
This change makes it so the gzipped library respects quality values when clients send them. Clients would now get a gzipped file rather than brotli encoded file (if possible) if they sent a header like:
```
Accept-Encoding: gzip;q=1, br;q=0.7
```

The other nice thing about this change is that `header.ParseAccept()` now only needs to be called one time; previously it was called twice, once for each encoding (brotli and gzip).

It should also now be a lot fewer lines of code to add new encodings support to this library. I considered adding deflate, but deflate is super old/deprecated and I don't know of any clients supporting deflate but not gzip, so I didn't see the point.

I added some new tests, and made the previous gzip tests [table driven](https://github.com/golang/go/wiki/TableDrivenTests).