### PR TITLE
Fixed withIndexHTML example when leading / is stripped

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ over the behavior. For example, to add support for `index.html` files in directo
 ```go
 func withIndexHTML(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasSuffix(r.URL.Path, "/") {
+		if strings.HasSuffix(r.URL.Path, "/") || len(r.URL.Path) == 0 {
 			newpath := path.Join(r.URL.Path, "index.html")
 			r.URL.Path = newpath
 		}


### PR DESCRIPTION
When leading / is stripped, withIndexHTML receives "" as URL path and doesn't handle it as "/".
Fix for #16 (2nd issue)